### PR TITLE
ユーザー名pi以外に対応

### DIFF
--- a/run_scratch2mcpi.py
+++ b/run_scratch2mcpi.py
@@ -2,7 +2,7 @@
 import os
 import glob
 
-MCPI_TEMPLATE = "/home/pi/Documents/Scratch Projects/mcpi_template.sb"
+MCPI_TEMPLATE = os.environ['HOME'] + "/Documents/Scratch Projects/mcpi_template.sb"
 NU_SCRATCH = "/usr/share/scratch/NuScratch*.image"
 SQUEAK_STACK = "/usr/bin/squeak-stack"
 
@@ -33,4 +33,4 @@ else:
      sleep = 30
   os.system("scratch --document \"%s\" & sleep %d" % (MCPI_TEMPLATE, sleep))
 
-os.system("lxterminal -t Scratch2MCPI -e python /home/pi/scratch2mcpi/scratch2mcpi.py")
+os.system("lxterminal -t Scratch2MCPI -e python " + os.environ['HOME'] + "/scratch2mcpi/scratch2mcpi.py")

--- a/scratch2mcpi_terminal.sh
+++ b/scratch2mcpi_terminal.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 sudo ps aux | grep 'scratch2mcpi.py' | grep -v grep | awk '{print $2}' | xargs sudo kill -9
-lxterminal -t Scratch2MCPI -e python /home/pi/scratch2mcpi/scratch2mcpi.py
+lxterminal -t Scratch2MCPI -e python $HOME/scratch2mcpi/scratch2mcpi.py
 


### PR DESCRIPTION
ユーザー名がpi以外の場合にscratch2mcpiの起動に失敗するため環境変数を使用するようにしました。